### PR TITLE
Prevent error, if data is null

### DIFF
--- a/lib/sanitizers.js
+++ b/lib/sanitizers.js
@@ -8,12 +8,12 @@ const {
 	trim,
 } = require('validator');
 
-const boolean = (data) => toBoolean(data, true);
-const date = (data) => toDate(data);
-const email = (data) => normalizeEmail(data);
-const float = (data) => toFloat(data);
-const int = (data) => toInt(data);
-const text = (data) => trim(escape(data));
+const boolean = (data) => data != null ? toBoolean(data, true) : null;
+const date = (data) => data != null ? toDate(data) : null;
+const email = (data) => data != null ? normalizeEmail(data) : null;
+const float = (data) => data != null ? toFloat(data) : null;
+const int = (data) => data != null ? toInt(data) : null;
+const text = (data) => data != null ? trim(escape(data)) : null;
 
 exports.boolean = boolean;
 exports.date = date;


### PR DESCRIPTION
Makes something like this possible:

```
"name": {
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": "object",
  "properties": {
    "name": { "type": ["string", "null"], "sanitize": "text" }
  }
}
```